### PR TITLE
add purchasedDirectly to AccessStatus return data structure

### DIFF
--- a/src/main/java/com/cleeng/apiv3/domain/AccessStatus.java
+++ b/src/main/java/com/cleeng/apiv3/domain/AccessStatus.java
@@ -10,4 +10,5 @@ public class AccessStatus implements Serializable {
 	public String grantType;
 	public Long expiresAt;
 	public String socialCommissionUrl;
+	public boolean purchasedDirectly;
 }


### PR DESCRIPTION
look like current version of cleeng returns purchasedDirectly, probably instead of socialCommissionUrl, but it's safe to leave it there
